### PR TITLE
Fix build with gcc 13.1.1

### DIFF
--- a/types.h
+++ b/types.h
@@ -39,6 +39,7 @@
 #include <vector>
 #include <fstream>
 #include <array>
+#include <cstdint>
 
 class Error : public std::runtime_error
 {


### PR DESCRIPTION
Hello, I'm the maintainer of the AUR pkgbuilds of alacenc and flacon, with the update of GCC to v13.1.1 `<cstdint>` need to be added otherwise the build fail

i.e.
```

In file included from /home/fabio/Dev/Github/PKGBUILD/alacenc/src/alacenc/tags.h:37,
                 from /home/fabio/Dev/Github/PKGBUILD/alacenc/src/alacenc/tags.cpp:34:
/home/fabio/Dev/Github/PKGBUILD/alacenc/src/alacenc/types.h:51:8: error: 'uint8_t' does not name a type
   51 | inline uint8_t  toBigEndian(uint8_t value)  { return value; }
      |        ^~~~~~~
/home/fabio/Dev/Github/PKGBUILD/alacenc/src/alacenc/types.h:42:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   41 | #include <array>
  +++ |+#include <cstdint>
   42 | 
/home/fabio/Dev/Github/PKGBUILD/alacenc/src/alacenc/types.h:52:8: error: 'uint16_t' does not name a type
   52 | inline uint16_t toBigEndian(uint16_t value) { return __builtin_bswap16(value); }
      |        ^~~~~~~~
/home/fabio/Dev/Github/PKGBUILD/alacenc/src/alacenc/types.h:52:8: note: 'uint16_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
/home/fabio/Dev/Github/PKGBUILD/alacenc/src/alacenc/types.h:53:8: error: 'uint32_t' does not name a type
   53 | inline uint32_t toBigEndian(uint32_t value) { return __builtin_bswap32(value); }
      |        ^~~~~~~~
[...]
```
