### PR TITLE
Fix PowerPC build

### DIFF
--- a/atoms.cpp
+++ b/atoms.cpp
@@ -655,7 +655,7 @@ OutFile &operator<<(OutFile &os, const FreeAtom &atom)
 {
     os << uint32_t(atom.mSize);
     os << "free";
-    for (uint i = 0; i < atom.mSize - 8; ++i) {
+    for (unsigned i = 0; i < atom.mSize - 8; ++i) {
         os << '\0';
     }
     return os;

--- a/vendor/alac/codec/EndianPortable.c
+++ b/vendor/alac/codec/EndianPortable.c
@@ -41,6 +41,8 @@
 #define TARGET_RT_LITTLE_ENDIAN 1
 #elif defined (TARGET_OS_WIN32)
 #define TARGET_RT_LITTLE_ENDIAN 1
+#else
+#define TARGET_RT_LITTLE_ENDIAN 0
 #endif
 
 #ifndef TARGET_RT_LITTLE_ENDIAN


### PR DESCRIPTION
The earlier commit does not fix PowerPC build, since `TARGET_RT_LITTLE_ENDIAN` macro is left undefined, and the error is triggered. In fact, merely dropping the error would work fine, like here: https://github.com/mikebrady/alac/blob/96dd59d17b776a7dc94ed9b2c2b4a37177feb3c4/codec/EndianPortable.c#L36-L44
However we keep the error but still fix the build.

Another issue is that `uint` is undefined in `atoms.cpp`. Use `unsigned` instead, which is standard C.