### PR TITLE
Update docopt sub-repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ add_subdirectory(vendor/docopt EXCLUDE_FROM_ALL)
 
 
 add_executable(${PROJECT_NAME} ${SOURCES})
-target_link_libraries(${PROJECT_NAME} alac_s docopt_s)
+target_link_libraries(${PROJECT_NAME} alac_s docopt)
 
 install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin)
 

--- a/vendor/docopt/.gitrepo
+++ b/vendor/docopt/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/docopt/docopt.cpp.git
 	branch = master
-	commit = 6f5de76970be94a6f1e4556d1716593100e285d2
-	parent = 3cc37d0e8a5ac5a13c90958ed4fcb0a1b6338181
+	commit = 05d507da0d153faff381f44968833ebffdc03447
+	parent = 0696571555bb908c4d52e7e71a639e437460918f
 	method = merge
-	cmdver = 0.4.3
+	cmdver = 0.4.9

--- a/vendor/docopt/CMakeLists.txt
+++ b/vendor/docopt/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(docopt.cpp VERSION 0.6.2)
 
 include(GNUInstallDirs)
@@ -34,44 +34,21 @@ set(docopt_HEADERS
 #============================================================================
 # Compile targets
 #============================================================================
-if(MSVC OR XCODE)
-    # MSVC requires __declspec() attributes, which are achieved via the 
-    # DOCOPT_DLL and DOCOPT_EXPORTS macros below. Since those macros are only
-    # defined when building a shared library, we must build the shared and
-    # static libraries completely separately.
-    # Xcode does not support libraries with only object files as sources.
-    # See https://cmake.org/cmake/help/v3.0/command/add_library.html?highlight=add_library
-    add_library(docopt SHARED ${docopt_SOURCES} ${docopt_HEADERS})
-    add_library(docopt_s STATIC ${docopt_SOURCES} ${docopt_HEADERS})
-else()
-    # If not using MSVC or Xcode, we will create an intermediate object target
-    # to avoid compiling the source code twice.
-    add_library(docopt_o OBJECT ${docopt_SOURCES} ${docopt_HEADERS})
-    set_target_properties(docopt_o PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
-
-    add_library(docopt SHARED $<TARGET_OBJECTS:docopt_o>)
-	set_target_properties(docopt PROPERTIES
-			VERSION ${PROJECT_VERSION}
-			SOVERSION ${PROJECT_VERSION_MAJOR}
-			)
-    add_library(docopt_s STATIC $<TARGET_OBJECTS:docopt_o>)
-endif()
+add_library(docopt ${docopt_SOURCES} ${docopt_HEADERS})
+set_target_properties(docopt PROPERTIES
+  VERSION ${PROJECT_VERSION}
+  SOVERSION ${PROJECT_VERSION_MAJOR}
+)
 
 target_include_directories(docopt PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}> $<INSTALL_INTERFACE:include/docopt>)
-target_include_directories(docopt_s PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}> $<INSTALL_INTERFACE:include/docopt>)
 
-if(MSVC)
+if(MSVC AND BUILD_SHARED_LIBS)
     # DOCOPT_DLL: Must be specified when building *and* when using the DLL.
     #             That's what the "PUBLIC" means.
     # DOCOPT_EXPORTS: Must use __declspec(dllexport) when building the DLL.
     #                 "PRIVATE" means it's only defined when building the DLL.
     target_compile_definitions(docopt PUBLIC  DOCOPT_DLL
                                       PRIVATE DOCOPT_EXPORTS)
-endif()
-
-if(NOT MSVC)
-	set_target_properties(docopt PROPERTIES OUTPUT_NAME docopt)
-	set_target_properties(docopt_s PROPERTIES OUTPUT_NAME docopt)
 endif()
 
 if(USE_BOOST_REGEX)
@@ -82,9 +59,6 @@ if(USE_BOOST_REGEX)
     find_package(Boost 1.53 REQUIRED COMPONENTS regex)
     include_directories(${Boost_INCLUDE_DIRS})
     target_link_libraries(docopt ${Boost_LIBRARIES})
-	if(WITH_STATIC)
-		target_link_libraries(docopt_s ${Boost_LIBRARIES})
-	endif()
 endif()
 
 #============================================================================
@@ -117,10 +91,12 @@ endif()
 set(export_name "docopt-targets")
 
 # Runtime package
-install(TARGETS docopt EXPORT ${export_name} DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(TARGETS docopt EXPORT ${export_name}
+	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 # Development package
-install(TARGETS docopt_s EXPORT ${export_name} DESTINATION ${CMAKE_INSTALL_LIBDIR})
 install(FILES ${docopt_HEADERS} DESTINATION include/docopt)
 
 # CMake Package

--- a/vendor/docopt/README.rst
+++ b/vendor/docopt/README.rst
@@ -87,7 +87,7 @@ Alternatively manual installation is done using (unix)::
 To link *docopt.cpp*, the simplest is to use CMake. The general structure of your
 ``CMakeLists.txt`` would be as follows::
 
-    cmake_minimum_required(VERSION 3.1)
+    cmake_minimum_required(VERSION 3.5)
 
     project(example)
 

--- a/vendor/docopt/docopt.h
+++ b/vendor/docopt/docopt.h
@@ -9,13 +9,6 @@
 #ifndef docopt__docopt_h_
 #define docopt__docopt_h_
 
-#include "docopt_value.h"
-
-#include <map>
-#include <vector>
-#include <string>
-#include <stdexcept>
-
 #ifdef DOCOPT_HEADER_ONLY
     #define DOCOPT_INLINE inline
     #define DOCOPT_API
@@ -40,6 +33,13 @@
         #define DOCOPT_API
     #endif
 #endif
+
+#include "docopt_value.h"
+
+#include <map>
+#include <vector>
+#include <string>
+#include <stdexcept>
 
 namespace docopt {
 	

--- a/vendor/docopt/docopt_value.h
+++ b/vendor/docopt/docopt_value.h
@@ -105,7 +105,7 @@ namespace docopt {
 	};
 
 	/// Write out the contents to the ostream
-	std::ostream& operator<<(std::ostream&, value const&);
+	DOCOPT_API std::ostream& operator<<(std::ostream&, value const&);
 }
 
 namespace std {

--- a/vendor/docopt/run_tests.py
+++ b/vendor/docopt/run_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import re
 import sys
@@ -56,17 +56,17 @@ for _, doc, cases in parse_test(tests):
 
 		failures += 1
 
-		print "="*40
-		print doc
-		print ':'*20
-		print prog, argv
-		print '-'*20
+		print("="*40)
+		print(doc)
+		print(':'*20)
+		print(prog, argv)
+		print('-'*20)
 		if out:
-			print out
-		print error
+			print(out)
+		print(error)
 
 if failures:
-	print "%d failures" % failures
+	print("%d failures" % failures)
 	sys.exit(1)
 else:
-	print "PASS (%d)" % passes
+	print("PASS (%d)" % passes)


### PR DESCRIPTION
- Update `vendor/docopt` as it now has a minimum required CMake version of 3.5, making the overall
  minimum required CMake version of alacenc be 3.5. This makes alacenc CMake-4 compatible.
- Build tested on AMD64 and runtime tested by converting a [wav sample](https://download.samplelib.com/wav/sample-12s.wav) to m4a